### PR TITLE
Improves message for repeated email

### DIFF
--- a/app/socialregister/users/forms.py
+++ b/app/socialregister/users/forms.py
@@ -24,7 +24,11 @@ class CompleteDataForm(forms.ModelForm):
     def clean_email(self):
         email = self.cleaned_data.get('email')
         if email and User.objects.filter(email=email).count():
-            raise forms.ValidationError(u'Email addresses must be unique.')
+            message = """
+                <p class='errorlist'>Hay un usuario registrado con este correo
+                <a href="/users/logout/">Ingresa con otra cuenta</a></p>
+            """
+            raise forms.ValidationError(message)
         return email
 
 

--- a/app/templates/users/complete_data.html
+++ b/app/templates/users/complete_data.html
@@ -8,9 +8,13 @@
             <h3>Social login <span class="small">Completa tus datos</a></span></h3>
             {% csrf_token %}
             <hr/>
-            <table>
-                {{ form.as_table }}
-            </table>
+            {% for error in form.email.errors %}
+                {{ error|safe }}
+            {% endfor %}
+            <div class="form-group">
+                <label for="email">Email:</label>
+                {{ form.email }}
+            </div>
             <br/>
             <div class="form-group">
                 <input type="submit" class="btn btn-primary btn-block" value="Guardar" />


### PR DESCRIPTION
## Tareas relacionadas
- [[socialregister] Mostrar mensaje de error amigable (y posibilidad de loguearme con la cuenta existente) cuando al registrarme vía red social proporciono un mail que ya existe.](http://manoderecha.net/md/index.php/task/84257)
## Descripción del problema

Cuando existe un correo y que lo proporciono después de ingresar con mi cuenta de twitter (no me proporciona el correo) debería aparecerme un mensaje más amigable y ligar esa cuenta con el correo existente.
## Descripción de la solución

Ahora muestra un mensaje más amigable y con una liga invitando al usuario a ingresar con otra cuenta.
## Plan de pruebas

Me registre con twitter y repetí un correo que ya estaba registrado y me mostró un mensaje más amigable y una liga invitándome a ingresar con otra cuenta.
